### PR TITLE
Moved Browserify stuff into its own factory

### DIFF
--- a/browser/js/common/factories/BrowserifyFactory.js
+++ b/browser/js/common/factories/BrowserifyFactory.js
@@ -1,0 +1,8 @@
+app.factory('BrowserifyFactory', function() {
+    var BrowserifyFactory = {};
+
+    BrowserifyFactory.beautifyHTML = require('js-beautify').html;
+    BrowserifyFactory.beautifyCSS = require('js-beautify').css;
+
+    return BrowserifyFactory;
+})

--- a/browser/js/create-layout/create-layout-controller.js
+++ b/browser/js/create-layout/create-layout-controller.js
@@ -1,4 +1,4 @@
-app.controller("CreateLayoutCtrl", function($scope, $compile, theUser, GridCompFactory, GridFactory, ExportFactory) {
+app.controller("CreateLayoutCtrl", function($scope, $compile, theUser, GridCompFactory, GridFactory, ExportFactory, BrowserifyFactory) {
 
     $scope.user = theUser;
     $scope.main_grid = GridFactory.getMainGrid();
@@ -12,7 +12,7 @@ app.controller("CreateLayoutCtrl", function($scope, $compile, theUser, GridCompF
        GridFactory.addNestedGrid($scope, id);
     }
 
-    $scope.removeWidget = GridFactory.removeWidget; 
+    $scope.removeWidget = GridFactory.removeWidget;
 
     $scope.saveGrid = function (){
       GridFactory.saveGrid($scope.user);
@@ -28,13 +28,11 @@ app.controller("CreateLayoutCtrl", function($scope, $compile, theUser, GridCompF
     //===== Exporting ===== //
     // TODO disable button if grid is empty
 
-    var beautify = require('js-beautify').html;
-
     $scope.exportHTML = function(){
       GridFactory.saveGrid($scope.user);
       var html = ExportFactory.convertToHTML();
       if (html) {
-        html = beautify(html, { indent_size: 4 });
+        html = BrowserifyFactory.beautifyHTML(html, { indent_size: 4 });
         $scope.convertedHTML = html;
 
         var htmlBlob = new Blob([html], {type : 'text/html'});

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "postinstall": "gulp build",
     "start": "nodemon --watch server -e js,html server/start.js",
-    "build-js": "browserify browser/js/create-layout/create-layout-controller.js -o node_modules/findem.js",
-    "watch-js": "watchify browser/js/create-layout/create-layout-controller.js -o node_modules/findem.js -v"
+    "build-js": "browserify browser/js/common/factories/BrowserifyFactory.js -o node_modules/browserify.js",
+    "watch-js": "watchify browser/js/common/factories/BrowserifyFactory.js -o node_modules/browserify.js -v"
   },
   "engines": {
     "node": ">=4.0.0"

--- a/server/app/views/index.html
+++ b/server/app/views/index.html
@@ -23,7 +23,7 @@
     <script src="/angular-ui-bootstrap/ui-bootstrap-tpls.js"></script>
     <script src="/socket.io-client/socket.io.js"></script>
     <script src="/main.js"></script>
-    <script src="/findem.js"></script>
+    <script src="/browserify.js"></script>
 </head>
 <body ng-app="FullstackGeneratedApp">
     <script>document.write('<script src="http://' + (location.host || 'localhost').split(':')[0] + ':35729/livereload.js?snipver=1"></' + 'script>')</script>


### PR DESCRIPTION
I moved Browserify into it's own factory. This means you don't have to "npm run build-js" every time we modify the create-layout controller. Just build it once and it should be good. 
