### PR TITLE
Fix nested grids in templates - closes #94, and closes #96

### DIFF
--- a/browser/js/common/factories/GridFactory.js
+++ b/browser/js/common/factories/GridFactory.js
@@ -102,9 +102,6 @@ app.factory('GridFactory', function($http, $compile, PageFactory, ProjectFactory
         var newGrid = $('#' + newGridID).gridstack(options).data('gridstack');
         GridFactory.nestedGrids[newGridID] = newGrid;
 
-       
-        console.log("id is", id);
-
         // add an Add Widget Button to the newly nested grid
         $("#" + "lasso-button-box-" + id )
             .append($compile("<button title='Add nested grid' ng-click='addNewGridElement(nestedGrids." + newGridID + ")'><span class='glyphicon glyphicon-plus'></span></button>")(scope));
@@ -154,12 +151,15 @@ app.factory('GridFactory', function($http, $compile, PageFactory, ProjectFactory
             };
         });
 
+        GridFactory.savedGrid.gridCount = GridFactory.counter;
+
     }
 
     GridFactory.saveGridBackend = function(page) {
         var changes = {
             grid: GridFactory.savedGrid,
-            css: StyleSaveLoadFactory.stylingToSave()
+            css: StyleSaveLoadFactory.stylingToSave(),
+            gridCount:  GridFactory.counter
         };
         PageFactory.savePage(page._id, changes)
             .then(function(updatedPage) {
@@ -180,10 +180,15 @@ app.factory('GridFactory', function($http, $compile, PageFactory, ProjectFactory
 
     GridFactory.loadGrid = function(scope, page) {
         GridFactory.clearGrid();
+
         if (GridFactory.savedGrid.length === 0) {
             if (page) {
                 GridFactory.savedGrid = page.grid;
+                GridFactory.savedGrid.gridCount = page.gridCount;
+                GridFactory.counter = page.gridCount;
             }
+        } else {
+            GridFactory.counter = GridFactory.savedGrid.gridCount;
         }
         _.each(GridFactory.savedGrid, function(node) {
             if (node.parentId === "main-grid") { // should load main-grid first as it's first in the array

--- a/browser/js/common/factories/GridFactory.js
+++ b/browser/js/common/factories/GridFactory.js
@@ -51,7 +51,7 @@ app.factory('GridFactory', function($http, $compile, PageFactory, ProjectFactory
 
     // helper function to create a new element
     GridFactory.createElement = function(scope, id, content) {
-        var content = content || "<p>Your content here</p>";
+        var content = content || "Your content here";
         var el = $compile("<div class='grid-stack-item' id=" +
             id + "><div class='grid-stack-item-content new-element container'>\
   <div class='row'>\
@@ -64,8 +64,7 @@ app.factory('GridFactory', function($http, $compile, PageFactory, ProjectFactory
   <button class='lasso-x' id='lasso-x-btn-" + id + "' ng-click='addNestedGrid(" +
             id + ")' class='btn btn-default lasso-nest-btn' title='Add nested grid' id='lasso-nest-btn-" +
             id + "'><span class='glyphicon glyphicon-th'></span></button>\
-            <button ng-click='editHTML(" +id + ")'><span class='glyphicon glyphicon-edit'></span></button>\
-            <button style-nested-grid-item data-element-selector=" + id + "></button>\
+            <button title='Edit HTML' ng-click='editHTML(" +id + ")'><span class='glyphicon glyphicon-edit'></span></button>\
             </div></div></div>")(scope);
 
         return el;
@@ -93,18 +92,21 @@ app.factory('GridFactory', function($http, $compile, PageFactory, ProjectFactory
             newGridID + "'></div>")(scope));
 
         thisWidget.append($compile(" <div class='row nested-buttons'>\
-  <div class='lasso-button-box'>\
-  <button ng-click='removeWidget(" + id + ")'><span class='glyphicon glyphicon-remove'></span></button>\
-   <button ng-click='editHTML(" +id + ")'><span class='glyphicon glyphicon-edit'></span></button>\
-  <button style-nested-grid-item data-element-selector=" + id + "></button>\
+  <div class='lasso-button-box' id='lasso-button-box-"+id+"''>\
+  <button title='Remove widget' ng-click='removeWidget(" + id + ")'><span class='glyphicon glyphicon-remove'></span></button>\
+   <button title='Edit HTML' ng-click='editHTML(" +id + ")'><span class='glyphicon glyphicon-edit'></span></button>\
+  <styling-selector data-style-selector-ref='" + id + "'></styling-selector>\
   </div></div>")(scope))
 
         // save the new grid to nestedGrids object on the $scope
         var newGrid = $('#' + newGridID).gridstack(options).data('gridstack');
         GridFactory.nestedGrids[newGridID] = newGrid;
 
+       
+        console.log("id is", id);
+
         // add an Add Widget Button to the newly nested grid
-        $("#" + id + " .lasso-button-box")
+        $("#" + "lasso-button-box-" + id )
             .append($compile("<button title='Add nested grid' ng-click='addNewGridElement(nestedGrids." + newGridID + ")'><span class='glyphicon glyphicon-plus'></span></button>")(scope));
 
         return newGrid;
@@ -140,6 +142,7 @@ app.factory('GridFactory', function($http, $compile, PageFactory, ProjectFactory
             el = $(el);
             var node = el.data('_gridstack_node');
             var userContent = getUserContent(el.context.innerHTML);
+
             return { // store content here too.
                 id: el.attr('id'),
                 parentId: el[0].offsetParent.id,
@@ -168,7 +171,7 @@ app.factory('GridFactory', function($http, $compile, PageFactory, ProjectFactory
         GridFactory.main_grid.remove_all();
         GridFactory.nestedGrids = {};
         GridFactory.nestedGrids["main-grid"] = GridFactory.main_grid;
-
+        
     }
 
     GridFactory.clearSavedGrid = function() {
@@ -207,12 +210,12 @@ app.factory('GridFactory', function($http, $compile, PageFactory, ProjectFactory
 
         // remove and re-add buttons to the outer grid div
         $('#lasso-button-box-' + parentId).remove();
-
+        
         thisWidget.append($compile(" <div class='row nested-buttons'>\
   <div class='lasso-button-box'>\
   <button ng-click='removeWidget(" + parentId + ")'><span class='glyphicon glyphicon-remove'></span></button>\
    <button ng-click='editHTML(" + parentId + ")'><span class='glyphicon glyphicon-edit'></span></button>\
-  <button style-nested-grid-item data-element-selector=" + parentId + "></button>\
+  <styling-selector data-style-selector-ref='" + parentId + "'></styling-selector>\
   <button title='Add nested grid' ng-click='addNewGridElement(nestedGrids." + node.parentId + ")'><span class='glyphicon glyphicon-plus'></span></button>\
             </div></div>")(scope));
 
@@ -224,7 +227,7 @@ app.factory('GridFactory', function($http, $compile, PageFactory, ProjectFactory
         var el = GridFactory.createElement(scope, node.id, node.content);
         GridFactory.nestedGrids[node.parentId].add_widget(el, node.x, node.y, node.width, node.height, false);
 
-
+        
     }
 
     return GridFactory;

--- a/browser/js/common/factories/GridFactory.js
+++ b/browser/js/common/factories/GridFactory.js
@@ -65,6 +65,7 @@ app.factory('GridFactory', function($http, $compile, PageFactory, ProjectFactory
             id + ")' class='btn btn-default lasso-nest-btn' title='Add nested grid' id='lasso-nest-btn-" +
             id + "'><span class='glyphicon glyphicon-th'></span></button>\
             <button title='Edit HTML' ng-click='editHTML(" +id + ")'><span class='glyphicon glyphicon-edit'></span></button>\
+            <button style-nested-grid-item data-element-selector=" + id + "></button>\
             </div></div></div>")(scope);
 
         return el;
@@ -95,7 +96,7 @@ app.factory('GridFactory', function($http, $compile, PageFactory, ProjectFactory
   <div class='lasso-button-box' id='lasso-button-box-"+id+"''>\
   <button title='Remove widget' ng-click='removeWidget(" + id + ")'><span class='glyphicon glyphicon-remove'></span></button>\
    <button title='Edit HTML' ng-click='editHTML(" +id + ")'><span class='glyphicon glyphicon-edit'></span></button>\
-  <styling-selector data-style-selector-ref='" + id + "'></styling-selector>\
+ <button style-nested-grid-item data-element-selector=" + id + "></button>\
   </div></div>")(scope))
 
         // save the new grid to nestedGrids object on the $scope
@@ -220,7 +221,7 @@ app.factory('GridFactory', function($http, $compile, PageFactory, ProjectFactory
   <div class='lasso-button-box'>\
   <button ng-click='removeWidget(" + parentId + ")'><span class='glyphicon glyphicon-remove'></span></button>\
    <button ng-click='editHTML(" + parentId + ")'><span class='glyphicon glyphicon-edit'></span></button>\
-  <styling-selector data-style-selector-ref='" + parentId + "'></styling-selector>\
+   <button style-nested-grid-item data-element-selector=" + parentId + "></button>\
   <button title='Add nested grid' ng-click='addNewGridElement(nestedGrids." + node.parentId + ")'><span class='glyphicon glyphicon-plus'></span></button>\
             </div></div>")(scope));
 

--- a/browser/js/common/factories/GridFactory.js
+++ b/browser/js/common/factories/GridFactory.js
@@ -51,7 +51,7 @@ app.factory('GridFactory', function($http, $compile, PageFactory, ProjectFactory
 
     // helper function to create a new element
     GridFactory.createElement = function(scope, id, content) {
-        var content = content || "Your content here";
+        var content = content || "<p>Your content here</p>";
         var el = $compile("<div class='grid-stack-item' id=" +
             id + "><div class='grid-stack-item-content new-element container'>\
   <div class='row'>\

--- a/browser/js/create-layout/create-layout-controller.js
+++ b/browser/js/create-layout/create-layout-controller.js
@@ -200,6 +200,7 @@ app.controller("CreateLayoutCtrl", function($scope, AUTH_EVENTS, $rootScope, the
         ModalFactory.templateModal.result.then(function(selectedItem){
             GridFactory.clearSavedGrid();
             GridFactory.loadGrid($scope, selectedItem);
+            $scope.nestedGrids = GridFactory.getNestedGrids();
         })
     }
 

--- a/seed.js
+++ b/seed.js
@@ -46,6 +46,7 @@ var seedTemplates = function() {
     var templates = [
         {
             name: "Grid squares 4 x 4 with navbar",
+            gridCount: 18,
             grid: [
                 {
                 "id": "0",
@@ -208,6 +209,7 @@ var seedTemplates = function() {
 
         {
             "name": "Content field - side columns - nav bar - large cover image",
+            "gridCount": 15,
             "grid": [
                 {
                   "id": "1",
@@ -316,6 +318,7 @@ var seedTemplates = function() {
 
         {
             name: "Simple gallery - 3 x 3 square grid",
+            gridCount: 9,
             grid: [ 
                  { id: '1',
                    parentId: 'main-grid',

--- a/server/db/models/page.js
+++ b/server/db/models/page.js
@@ -5,7 +5,8 @@ var ObjectId = mongoose.Schema.Types.ObjectId;
 var PageSchema = new mongoose.Schema({
 	name: { type: String, required: true},
 	css: String,
-	grid: []
+	grid: [],
+	gridCount: { type: Number, default: 0}
 })
 
 module.exports = mongoose.model('Page', PageSchema);

--- a/server/db/models/template.js
+++ b/server/db/models/template.js
@@ -3,7 +3,8 @@ var mongoose = require('mongoose');
 
 var TemplateSchema = new mongoose.Schema({
 	name: String,
-	grid: []
+	grid: [],
+	gridCount: { type: Number, default: 0}
 })
 
 module.exports = mongoose.model('Template', TemplateSchema);


### PR DESCRIPTION
Can now nest properly in loaded templates. Also fixed bug where grid counter was being reset to zero, even when loading a preexisting grid. Now we save that grid number to the backend and to the savedGrid object, and set our grid counter to that value whenever we load. UPDATED THE TEMPLATE SEED FILE AS WELL.
